### PR TITLE
Use codecov for coverage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Athena/bin/Debug/netcoreapp2.0/Athena.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Athena",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "taskName": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Athena/Athena.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Athena Scheduling Assistant
 
-| Windows | Linux | Style |
-| ------- | ----- | ----- |
-| [![Build status](https://ci.appveyor.com/api/projects/status/sfdfysdjn9806apq/branch/master?svg=true)](https://ci.appveyor.com/project/athena-scheduler/athena/branch/master) | [![Build Status](https://travis-ci.org/athena-scheduler/athena.svg?branch=master)](https://travis-ci.org/athena-scheduler/athena) | [![Codacy Badge](https://api.codacy.com/project/badge/Grade/013e28793a554168b6f2ac337df77ebc)](https://www.codacy.com/app/athena-scheduler/athena?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=athena-scheduler/athena&amp;utm_campaign=Badge_Grade) |
+| Windows | Linux | Style | Coverage |
+| ------- | ----- | ----- | -------- |
+| [![Build status](https://ci.appveyor.com/api/projects/status/sfdfysdjn9806apq/branch/master?svg=true)](https://ci.appveyor.com/project/athena-scheduler/athena/branch/master) | [![Build Status](https://travis-ci.org/athena-scheduler/athena.svg?branch=master)](https://travis-ci.org/athena-scheduler/athena) | [![Codacy Badge](https://api.codacy.com/project/badge/Grade/013e28793a554168b6f2ac337df77ebc)](https://www.codacy.com/app/athena-scheduler/athena?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=athena-scheduler/athena&amp;utm_campaign=Badge_Grade) | [![codecov](https://codecov.io/gh/athena-scheduler/athena/branch/master/graph/badge.svg)](https://codecov.io/gh/athena-scheduler/athena) |
 
 WIP

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,4 +6,4 @@ environment:
   ATHENA_DATA_TESTS_CON: Server=localhost;User ID=postgres;Password=Password12!;Database=postgres
 
 build_script:
-- ps: ./build.ps1
+- ps: ./build.ps1 -t CodeCov::Publish

--- a/build.cake
+++ b/build.cake
@@ -133,7 +133,7 @@ Task("CodeCov::Publish")
     .IsDependentOn("Test")
     .Does(() =>
 {
-    Codecov(GetFiles("./_tests/*_coverage.xml").Select(f => f.FullPath));
+    Codecov("./_tests/coverage.xml");
 });
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,10 @@
 #addin "nuget:?package=Cake.Docker&version=0.8.2"
+#addin "nuget:?package=Cake.Codecov&version=0.3.0"
+#tool "nuget:?package=Codecov&version=1.0.3"
+#tool "nuget:?package=OpenCover&version=4.6.519"
+
 #l "./build/AddMigration.cake"
+#l "./build/util.cake"
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -66,19 +71,9 @@ Task("Test::Unit")
     .IsDependentOn("Build")
     .Does(() =>
 {
-    EnsureDirectoryExists("_tests");
-
-    var settings = new DotNetCoreTestSettings
-    {
-        ArgumentCustomization = args => args.AppendSwitch("--results-directory", MakeAbsolute(Directory("_tests")).FullPath),
-        Configuration = configuration,
-        NoBuild = true,
-        Logger = "trx;LogFileName=UnitTestResults.trx",
-    };
-
     foreach(var project in GetFiles("./test/unit/**/*.csproj"))
     {
-        DotNetCoreTest(project.FullPath, settings);
+        TestProject(project);
     }
 });
 
@@ -87,8 +82,6 @@ Task("Test::Integration")
     .IsDependentOn("Build")
     .Does(() => 
 {
-    EnsureDirectoryExists("_tests");
-
     var container = Guid.Empty;
     if(HasArgument("UseDocker"))
     {
@@ -103,19 +96,11 @@ Task("Test::Integration")
         System.Threading.Thread.Sleep(10000);
     }
 
-    var settings = new DotNetCoreTestSettings
-    {
-        ArgumentCustomization = args => args.AppendSwitch("--results-directory", MakeAbsolute(Directory("_tests")).FullPath),
-        Configuration = configuration,
-        NoBuild = true,
-        Logger = "trx;LogFileName=IntegrationTestResults.trx",
-    };
-
     try
     {
         foreach(var project in GetFiles("./test/Integration/**/*.csproj"))
         {
-            DotNetCoreTest(project.FullPath, settings);
+            TestProject(project);
         }
     }
     finally
@@ -142,6 +127,13 @@ Task("Docker")
     .IsDependentOn("Dist")
     .Does(() =>
 {
+});
+
+Task("CodeCov::Publish")
+    .IsDependentOn("Test")
+    .Does(() =>
+{
+    Codecov(GetFiles("./_tests/*_coverage.xml").Select(f => f.FullPath));
 });
 
 //////////////////////////////////////////////////////////////////////

--- a/build/util.cake
+++ b/build/util.cake
@@ -8,7 +8,7 @@ public void TestProject(FilePath project)
         ArgumentCustomization = args => args.AppendSwitch("--results-directory", resultsDirectory),
         Configuration = configuration,
         NoBuild = true,
-        Logger = "trx;LogFileName=UnitTestResults.trx",
+        Logger = $"trx;LogFileName={project.GetFilenameWithoutExtension()}_results.trx"
     };
     var coverageSettings = new OpenCoverSettings
     {
@@ -22,7 +22,7 @@ public void TestProject(FilePath project)
         OpenCover(tool => {
                 tool.DotNetCoreTest(project.FullPath, settings);
             },
-            Directory(resultsDirectory) + File(project.GetFilenameWithoutExtension() + "_coverage.xml"),
+            Directory(resultsDirectory) + File("coverage.xml"),
             coverageSettings
         );
     }

--- a/build/util.cake
+++ b/build/util.cake
@@ -1,0 +1,34 @@
+public void TestProject(FilePath project)
+{
+    EnsureDirectoryExists("_tests");
+
+    var resultsDirectory = MakeAbsolute(Directory("_tests")).FullPath;
+    var settings = new DotNetCoreTestSettings
+    {
+        ArgumentCustomization = args => args.AppendSwitch("--results-directory", resultsDirectory),
+        Configuration = configuration,
+        NoBuild = true,
+        Logger = "trx;LogFileName=UnitTestResults.trx",
+    };
+    var coverageSettings = new OpenCoverSettings
+    {
+       OldStyle = true,
+       MergeOutput = true 
+    }.WithFilter("+[Athena.*]*")
+     .WithFilter("-[Athena.*.Tests]*");
+    
+    if(IsRunningOnWindows())
+    {
+        OpenCover(tool => {
+                tool.DotNetCoreTest(project.FullPath, settings);
+            },
+            Directory(resultsDirectory) + File(project.GetFilenameWithoutExtension() + "_coverage.xml"),
+            coverageSettings
+        );
+    }
+    else
+    {
+        Verbose("OpenCover is not supported on non-windows platforms. No code coverage will be generated");
+        DotNetCoreTest(project.FullPath, settings);
+    }
+}

--- a/src/Athena.Core/Athena.Core.csproj
+++ b/src/Athena.Core/Athena.Core.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 </Project>

--- a/src/Athena.Data/Athena.Data.csproj
+++ b/src/Athena.Data/Athena.Data.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Athena.Core\Athena.Core.csproj" />

--- a/src/Athena/Athena.csproj
+++ b/src/Athena/Athena.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />

--- a/test/Integration/Athena.Data.Tests/Athena.Data.Tests.csproj
+++ b/test/Integration/Athena.Data.Tests/Athena.Data.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <DebugType>Full</DebugType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Now that we're writing some tests we should track code coverage. Note that these reports are only generated on windows, the coverage tool does not support linux yet.

Stats are visible here: https://codecov.io/gh/athena-scheduler/athena. Note that while codacy supports code coverage (and I'd rather use a unified tool), it doesn't support `.net` coverage reports yet so we'd have to write our own importer.

If I did it right a bot should also comment on the PR like codacy.