### PR TITLE
Add support for gravatar

### DIFF
--- a/src/Athena.Data/Migrations/20180215110432_Identity.cs
+++ b/src/Athena.Data/Migrations/20180215110432_Identity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Athena.Core.Models.Identity;
 using Athena.Data.Repositories.Identity;
 using Microsoft.AspNetCore.Identity;
@@ -29,12 +30,12 @@ namespace Athena.Data.Migrations
 
                 role.NormalizedName = normalizer.Normalize(role.Name);
 
-                if (roles.FindByIdAsync(role.Id.ToString(), CancellationToken.None).GetAwaiter().GetResult() != null)
+                if (Task.Run(() => roles.FindByIdAsync(role.Id.ToString(), CancellationToken.None)).GetAwaiter().GetResult() != null)
                 {
                     return;
                 }
 
-                if (roles.CreateAsync(role, CancellationToken.None).GetAwaiter().GetResult() != IdentityResult.Success)
+                if (Task.Run(() => roles.CreateAsync(role, CancellationToken.None)).GetAwaiter().GetResult() != IdentityResult.Success)
                 {
                     throw new MigrationException("Failed to create administrator role");
                 }

--- a/src/Athena/Athena.csproj
+++ b/src/Athena/Athena.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="7.4.0" />
+    <PackageReference Include="GravatarHelper.AspNetCore" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />

--- a/src/Athena/Views/Shared/_Nav.cshtml
+++ b/src/Athena/Views/Shared/_Nav.cshtml
@@ -16,6 +16,7 @@
                 {
                     <li>
                         <div class="chip">
+                            <img gravatar-email="@Model.Student.Email" gravatar-size="80" gravatar-default-image="retro" gravatar-force-https="true" gravatar-rating="@GravatarRating.PG" alt="" />
                             @Model.Student.Name
                         </div>
                     </li>

--- a/src/Athena/Views/_ViewImports.cshtml
+++ b/src/Athena/Views/_ViewImports.cshtml
@@ -2,4 +2,6 @@
 @using Athena.Extensions
 @using Athena.Models
 @using Athena.Controllers
+@using GravatarHelper.Common
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, GravatarHelper.AspNetCore


### PR DESCRIPTION
Adds support for profile images via [gravatar](https://en.gravatar.com/)

![image](https://user-images.githubusercontent.com/794251/36636536-80c12a86-1996-11e8-89dc-7f07f9cd51e2.png)

Users who do not have an image set will see a random robot:

![image](https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro)