### PR TITLE
Avoid deadlocks on identity migrations (See #18)

### DIFF
--- a/src/Athena.Data/Migrations/20180215110432_Identity.cs
+++ b/src/Athena.Data/Migrations/20180215110432_Identity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Athena.Core.Models.Identity;
 using Athena.Data.Repositories.Identity;
 using Microsoft.AspNetCore.Identity;
@@ -29,12 +30,12 @@ namespace Athena.Data.Migrations
 
                 role.NormalizedName = normalizer.Normalize(role.Name);
 
-                if (roles.FindByIdAsync(role.Id.ToString(), CancellationToken.None).GetAwaiter().GetResult() != null)
+                if (Task.Run(() => roles.FindByIdAsync(role.Id.ToString(), CancellationToken.None)).GetAwaiter().GetResult() != null)
                 {
                     return;
                 }
 
-                if (roles.CreateAsync(role, CancellationToken.None).GetAwaiter().GetResult() != IdentityResult.Success)
+                if (Task.Run(() => roles.CreateAsync(role, CancellationToken.None)).GetAwaiter().GetResult() != IdentityResult.Success)
                 {
                     throw new MigrationException("Failed to create administrator role");
                 }


### PR DESCRIPTION
a515e90 introduced a change to use the role store for adding the default administrator user. Because our migration framework does not support async migrations, we manually call `.GetAwaiter().GetResult()`. It appears that this pattern **may** deadlock in certain use cases. By wrapping the async call in a `Task.Run(...).GetAwaiter().GetResult()` we can avoid this deadlock.

This is just a hotfix to get us up and running right now (Fixes #18). We should consider `.ConfigureAwait(false)` where applicable to avoid this in other places (although as far as I know the only place where we are calling async code from a sync context is in migrations, and even then this is the only instance).

If we add more migrations that need to call async methods, we should wrap this in an `AsyncMigration` to make this easier in the future (we don't care that the method is running sync, we just want to easily call async code from sync).