### PR TITLE
Add support for docker and docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: csharp
+sudo: required
 mono: latest
 dotnet: 2.0.0
 dist: trusty
 
 services:
   - postgresql
+  - docker
 
 addons:
   postgresql: "9.6"
@@ -14,4 +16,4 @@ cache:
     - src/Athena/node_modules
 
 script:
-  - ./build.sh
+  - ./build/travis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM microsoft/aspnetcore:2
+LABEL maintainer="Athena Developers"
+
+ENV ASPNETCORE_URLS=http://0.0.0.0:5000
+EXPOSE 5000
+
+COPY _dist/Athena/ /
+CMD ["dotnet", "/Athena.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,10 @@ LABEL maintainer="Athena Developers"
 ENV ASPNETCORE_URLS=http://0.0.0.0:5000
 EXPOSE 5000
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY contrib/ /contrib
 COPY _dist/Athena/ /
 CMD ["dotnet", "/Athena.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV ASPNETCORE_URLS=http://0.0.0.0:5000
 EXPOSE 5000
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y postgresql-client && \
+    apt-get install -y --no-install-recommends postgresql-client && \
     rm -rf /var/lib/apt/lists/*
 
 COPY contrib/ /contrib

--- a/build/travis.sh
+++ b/build/travis.sh
@@ -6,8 +6,8 @@ SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 CAKE_TASK=Default
 
-if [ "${TRAVIS_BRANCH}" == "master" ]; then
-    CAKE_TASK=Docker::Publish
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
+    CAKE_TASK=Docker::Push
     docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 fi
 

--- a/build/travis.sh
+++ b/build/travis.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+CAKE_TASK=Default
+
+if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    CAKE_TASK=Docker::Publish
+    docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+fi
+
+echo "Building task ${CAKE_TASK}"
+
+"${SCRIPT_ROOT}/../build.sh" -t "${CAKE_TASK}"

--- a/contrib/wait-postgres.sh
+++ b/contrib/wait-postgres.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PG_HOST="${1}"
+
+
+until psql -h "${PG_HOST}" -U "postgres" -c '\q' >/dev/null 2>&1; do
+    >&2 echo "Waiting for postgres to start"
+    sleep 1
+done
+
+>&2 echo "Postgres started"
+dotnet /Athena.dll

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  athena:
+    build: '.'
+    ports:
+      - "5000:5000"
+    environment:
+      - "ATHENA_CONNECTION_STRING=Server=db;User ID=postgres;Database=postgres"
+      # - AUTH_GOOGLE_CLIENT_KEY=...
+      # - AUTH_GOOGLE_CLIENT_SECRET=...
+    depends_on:
+      - db
+    command:
+      - /contrib/wait-postgres.sh
+      - db
+  db:
+    image: postgres:alpine

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.24.0" />
+    <package id="Cake" version="0.25.0" />
 </packages>


### PR DESCRIPTION
This adds tasks for generating a docker image which will automatically be pushed to the docker hub on master from travis-ci. I also added a docker-compose script, if you want to test it out, install [`docker-compose`](https://docs.docker.com/compose/install/) and do the following:

```bash
./build.sh -t Dist # or on windows: ./build.ps1 -t Dist
docker-compose up
```