### PR TITLE
Speed up builds by caching node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ services:
 addons:
   postgresql: "9.6"
 
+cache:
+  directories:
+    - src/Athena/node_modules
+
 script:
   - ./build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ install:
 
 services: postgresql96
 
+cache:
+ - 'src\Athena\node_modules'
+ - '%USERPROFILE%\.nuget\packages'
+
 build_script:
 - ps: ./build.ps1 -t CodeCov::Publish
 


### PR DESCRIPTION
Use the [Build Cache](https://www.appveyor.com/docs/build-cache/) on appveyor and the [Cache](https://docs.travis-ci.com/user/caching/) on travis to try to speed up builds. Linux isn't too bad but appveyor builds are painfully slow.