### PR TITLE
Include coverage for main athena assembly

### DIFF
--- a/build/util.cake
+++ b/build/util.cake
@@ -14,7 +14,9 @@ public void TestProject(FilePath project)
     {
        OldStyle = true,
        MergeOutput = true 
-    }.WithFilter("+[Athena.*]*")
+    }.WithFilter("+[Athena]*")
+     .WithFilter("+[Athena.*]*")
+     .WithFilter("-[Athena.Tests]*")
      .WithFilter("-[Athena.*.Tests]*");
     
     if(IsRunningOnWindows())


### PR DESCRIPTION
This fixes coverage results so when we start testing the main Athena assembly coverage is properly counted.