### PR TITLE
Use Minicover instead of OpenCover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 _dist/
 _tests/
 
+# MiniCover
+*coverage*
+*coverage*/
+
 # User-specific files
 *.suo
 *.user

--- a/build/util.cake
+++ b/build/util.cake
@@ -1,36 +1,14 @@
-public void TestProject(FilePath project)
+public void AllowFailure(Action action, Action<Exception> onException = null)
 {
-    EnsureDirectoryExists("_tests");
-
-    var resultsDirectory = MakeAbsolute(Directory("_tests")).FullPath;
-    var settings = new DotNetCoreTestSettings
+    try
     {
-        ArgumentCustomization = args => args.AppendSwitch("--results-directory", resultsDirectory),
-        Configuration = configuration,
-        NoBuild = true,
-        Logger = $"trx;LogFileName={project.GetFilenameWithoutExtension()}_results.trx"
-    };
-    var coverageSettings = new OpenCoverSettings
-    {
-       OldStyle = true,
-       MergeOutput = true 
-    }.WithFilter("+[Athena]*")
-     .WithFilter("+[Athena.*]*")
-     .WithFilter("-[Athena.Tests]*")
-     .WithFilter("-[Athena.*.Tests]*");
-    
-    if(IsRunningOnWindows())
-    {
-        OpenCover(tool => {
-                tool.DotNetCoreTest(project.FullPath, settings);
-            },
-            Directory(resultsDirectory) + File("coverage.xml"),
-            coverageSettings
-        );
+        action();
     }
-    else
+    catch (Exception ex)
     {
-        Verbose("OpenCover is not supported on non-windows platforms. No code coverage will be generated");
-        DotNetCoreTest(project.FullPath, settings);
+        if(onException != null)
+        {
+            onException(ex);
+        }
     }
 }

--- a/minicover/minicover.csproj
+++ b/minicover/minicover.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <DotNetCliToolReference Include="MiniCover" Version="2.0.0-ci-20180301063918" />
+  </ItemGroup>
+
+</Project>

--- a/src/Athena.Core.Validation/Athena.Core.Validation.csproj
+++ b/src/Athena.Core.Validation/Athena.Core.Validation.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="7.4.0" />

--- a/src/Athena.Core/Athena.Core.csproj
+++ b/src/Athena.Core/Athena.Core.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="2.0.1" />

--- a/src/Athena.Data/Athena.Data.csproj
+++ b/src/Athena.Data/Athena.Data.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Athena.Core\Athena.Core.csproj" />

--- a/src/Athena/Athena.csproj
+++ b/src/Athena/Athena.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="7.4.0" />

--- a/test/Integration/Athena.Data.Tests/Athena.Data.Tests.csproj
+++ b/test/Integration/Athena.Data.Tests/Athena.Data.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <DebugType>Full</DebugType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This enables code coverage on non-windows platforms and is still compatible with CodeCov. The metrics are a tad different since I don't think it includes branches, but for our use cases I think that is acceptable. Here's a preview of what you'll see if you use the build script:

![image](https://user-images.githubusercontent.com/794251/36861498-08722c14-1d52-11e8-847d-229b9bebd6fb.png)
