### PR TITLE
Do not allow duplicate entries in relationship tables

### DIFF
--- a/src/Athena.Data/Migrations/20180322190011_DropDuplicateLinks.cs
+++ b/src/Athena.Data/Migrations/20180322190011_DropDuplicateLinks.cs
@@ -1,0 +1,11 @@
+using SimpleMigrations;
+namespace Athena.Data.Migrations
+{
+    [Migration(20180322190011, "DropDuplicateLinks")]
+    public class DropDuplicateLinks : ScriptMigration
+    {
+        public DropDuplicateLinks() : base("20180322190011_DropDuplicateLinks.sql")
+        {
+        }
+    }
+}

--- a/src/Athena.Data/Migrations/src/20180322190011_DropDuplicateLinks.sql
+++ b/src/Athena.Data/Migrations/src/20180322190011_DropDuplicateLinks.sql
@@ -1,0 +1,110 @@
+DELETE FROM campus_x_institution T1 USING campus_x_institution T2
+WHERE T1.CTID < T2.CTID
+  AND T1.campus = T2.campus
+  AND T1.institution = T2.institution;
+
+ALTER TABLE campus_x_institution DROP CONSTRAINT IF EXISTS campus_x_institution_unique_link;
+ALTER TABLE campus_x_institution ADD CONSTRAINT campus_x_institution_unique_link UNIQUE (campus, institution);
+
+
+DELETE FROM student_x_completed_course T1 USING student_x_completed_course T2
+WHERE T1.CTID < T2.CTID
+  AND T1.student = T2.student
+  AND T1.course = T2.course;
+
+ALTER TABLE student_x_completed_course DROP CONSTRAINT IF EXISTS student_x_completed_course_unique_link;
+ALTER TABLE student_x_completed_course ADD CONSTRAINT student_x_completed_course_unique_link UNIQUE (student, course);
+
+
+DELETE FROM student_x_in_progress_course T1 USING student_x_in_progress_course T2
+WHERE T1.CTID < T2.CTID
+  AND T1.student = T2.student
+  AND T1.course = T2.course;
+
+ALTER TABLE student_x_in_progress_course DROP CONSTRAINT IF EXISTS student_x_in_progress_course_unique_link;
+ALTER TABLE student_x_in_progress_course ADD CONSTRAINT student_x_in_progress_course_unique_link UNIQUE (student, course);
+
+
+DELETE FROM course_x_offering T1 USING course_x_offering T2
+WHERE T1.CTID < T2.CTID
+  AND T1.course = T2.course
+  AND T1.offering = T2.offering;
+
+ALTER TABLE course_x_offering DROP CONSTRAINT IF EXISTS course_x_offering_unique_link;
+ALTER TABLE course_x_offering ADD CONSTRAINT course_x_offering_unique_link UNIQUE (course, offering);
+
+
+DELETE FROM course_requirements T1 USING course_requirements T2
+WHERE T1.CTID < T2.CTID
+  AND T1.course = T2.course
+  AND T1.requirement = T2.requirement;
+
+ALTER TABLE course_requirements DROP CONSTRAINT IF EXISTS course_requirements_unique_link;
+ALTER TABLE course_requirements ADD CONSTRAINT course_requirements_unique_link UNIQUE (course, requirement);
+
+
+DELETE FROM course_prereqs T1 USING course_prereqs T2
+WHERE T1.CTID < T2.CTID
+  AND T1.course = T2.course
+  AND T1.prereq = T2.prereq;
+
+ALTER TABLE course_prereqs DROP CONSTRAINT IF EXISTS course_prereqs_unique_link;
+ALTER TABLE course_prereqs ADD CONSTRAINT course_prereqs_unique_link UNIQUE (course, prereq);
+
+
+DELETE FROM course_concurrent_prereqs T1 USING course_concurrent_prereqs T2
+WHERE T1.CTID < T2.CTID
+  AND T1.course = T2.course
+  AND T1.prereq = T2.prereq;
+
+ALTER TABLE course_concurrent_prereqs DROP CONSTRAINT IF EXISTS course_concurrent_prereqs_unique_link;
+ALTER TABLE course_concurrent_prereqs ADD CONSTRAINT course_concurrent_prereqs_unique_link UNIQUE (course, prereq);
+
+
+DELETE FROM institution_x_student T1 USING institution_x_student T2
+WHERE T1.CTID < T2.CTID
+  AND T1.institution = T2.institution
+  AND T1.student = T2.student;
+
+ALTER TABLE institution_x_student DROP CONSTRAINT IF EXISTS institution_x_student_unique_link;
+ALTER TABLE institution_x_student ADD CONSTRAINT institution_x_student_unique_link UNIQUE (institution, student);
+
+
+DELETE FROM offering_x_meeting T1 USING offering_x_meeting T2
+WHERE T1.CTID < T2.CTID
+  AND T1.offering = T2.offering
+  AND T1.meeting = T2.meeting;
+
+ALTER TABLE offering_x_meeting DROP CONSTRAINT IF EXISTS offering_x_meeting_unique_link;
+ALTER TABLE offering_x_meeting ADD CONSTRAINT offering_x_meeting_unique_link UNIQUE (offering, meeting);
+
+
+DELETE FROM program_requirements T1 USING program_requirements T2
+WHERE T1.CTID < T2.CTID
+  AND T1.program = T2.program
+  AND T1.requirement = T2.requirement;
+
+ALTER TABLE program_requirements DROP CONSTRAINT IF EXISTS program_requirements_unique_link;
+ALTER TABLE program_requirements ADD CONSTRAINT program_requirements_unique_link UNIQUE (program, requirement);
+
+
+DELETE FROM student_x_program T1 USING student_x_program T2
+WHERE T1.CTID < T2.CTID
+  AND T1.student = T2.student
+  AND T1.program = T2.program;
+
+ALTER TABLE student_x_program DROP CONSTRAINT IF EXISTS student_x_program_unique_link;
+ALTER TABLE student_x_program ADD CONSTRAINT student_x_program_unique_link UNIQUE (student, program);
+
+
+DELETE FROM user_x_role T1 USING user_x_role T2
+WHERE T1.CTID < T2.CTID
+  AND T1.user_id = T2.user_id
+  AND T1.role_id = T2.role_id;
+
+ALTER TABLE user_x_role DROP CONSTRAINT IF EXISTS user_x_role_unique_link;
+ALTER TABLE user_x_role ADD CONSTRAINT user_x_role_unique_link UNIQUE (user_id, role_id);
+
+
+DROP TABLE IF EXISTS instituion_x_program;
+DROP TABLE IF EXISTS institution_x_program;

--- a/src/Athena.Data/Repositories/CampusRepository.cs
+++ b/src/Athena.Data/Repositories/CampusRepository.cs
@@ -53,7 +53,7 @@ namespace Athena.Data.Repositories
             );
 
         public async Task AssociateCampusWithInstitutionAsync(Campus campus, Institution institution) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO campus_x_institution VALUES (@campus, @institution)",
                 new {campus = campus.Id, institution = institution.Id}
             );

--- a/src/Athena.Data/Repositories/CourseRepository.cs
+++ b/src/Athena.Data/Repositories/CourseRepository.cs
@@ -123,7 +123,7 @@ namespace Athena.Data.Repositories
             );
 
         public async Task AddOfferingAsync(Course course, Offering offering) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO course_x_offering VALUES (@course, @offering)",
                 new {course = course.Id, offering = offering.Id}
             );
@@ -135,7 +135,7 @@ namespace Athena.Data.Repositories
             );
 
         public async Task AddSatisfiedRequirementAsync(Course course, Requirement requirement) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO course_requirements VALUES (@course, @requirement)",
                 new {course = course.Id, requirement = requirement.Id}
             );
@@ -147,7 +147,7 @@ namespace Athena.Data.Repositories
             );
 
         public async Task AddPrerequisiteAsync(Course course, Requirement prereq) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO course_prereqs VALUES (@course, @prereq)",
                 new {course = course.Id, prereq = prereq.Id}
             );
@@ -159,7 +159,7 @@ namespace Athena.Data.Repositories
             );
         
         public async Task AddConcurrentPrerequisiteAsync(Course course, Requirement prereq) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO course_concurrent_prereqs VALUES (@course, @prereq)",
                 new {course = course.Id, prereq = prereq.Id}
             );

--- a/src/Athena.Data/Repositories/InstitutionRepository.cs
+++ b/src/Athena.Data/Repositories/InstitutionRepository.cs
@@ -63,7 +63,7 @@ namespace Athena.Data.Repositories
             );
 
         public async Task EnrollStudentAsync(Institution institution, Student student) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO institution_x_student VALUES (@institution, @student)",
                 new { institution = institution.Id, student = student.Id }
             );

--- a/src/Athena.Data/Repositories/ProgramRepository.cs
+++ b/src/Athena.Data/Repositories/ProgramRepository.cs
@@ -82,7 +82,7 @@ namespace Athena.Data.Repositories
             );
 
         public async Task AddRequirementAsync(Program program, Requirement requirement) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO program_requirements VALUES (@program, @req)",
                 new {program = program.Id, req = requirement.Id}
             );

--- a/src/Athena.Data/Repositories/StudentRepository.cs
+++ b/src/Athena.Data/Repositories/StudentRepository.cs
@@ -38,7 +38,7 @@ namespace Athena.Data.Repositories
             );
 
         public async Task RegisterForProgramAsync(Student student, Program program) =>
-            await _db.ExecuteAsync(
+            await _db.InsertUniqueAsync(
                 "INSERT INTO student_x_program VALUES (@student, @program)",
                 new {student = student.Id, program = program.Id}
             );

--- a/test/Integration/Athena.Data.Tests/Repositories/CampusRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/CampusRepositoryTests.cs
@@ -71,6 +71,20 @@ namespace Athena.Data.Tests.Repositories
             Assert.Equal(campuses.Count, results.Count);
             Assert.All(campuses, c => Assert.Contains(c, results));
         }
+
+        [Theory, AutoData]
+        public async Task AssociateCampusWithInstitution_ThrowsForDuplicate(Campus campus, Institution institution)
+        {
+            var institutionRepo = new InstitutionRepository(_db);
+
+            await institutionRepo.AddAsync(institution);
+            await _sut.AddAsync(campus);
+
+            await _sut.AssociateCampusWithInstitutionAsync(campus, institution);
+
+            await Assert.ThrowsAnyAsync<DuplicateObjectException>(async () =>
+                await _sut.AssociateCampusWithInstitutionAsync(campus, institution));
+        }
         
         [Theory, AutoData]
         public async Task CanDisassociateCampusWithInstitution(Campus extra, List<Campus> campuses, Institution institution)

--- a/test/Integration/Athena.Data.Tests/Repositories/CourseRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/CourseRepositoryTests.cs
@@ -111,6 +111,20 @@ namespace Athena.Data.Tests.Repositories
         }
 
         [Theory, AutoData]
+        public async Task Requirement_ThrowsForDuplicate(Requirement req, Course course)
+        {
+            var requirementRepository = new RequirementRepository(_db);
+
+            await _institutions.AddAsync(course.Institution);
+            await _sut.AddAsync(course);
+            await requirementRepository.AddAsync(req);
+
+            await _sut.AddSatisfiedRequirementAsync(course, req);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.AddSatisfiedRequirementAsync(course, req));
+        }
+
+        [Theory, AutoData]
         public async Task TracksPrereqs(List<Requirement> prereqs, Course course)
         {
             var requirementRepository = new RequirementRepository(_db);
@@ -135,6 +149,20 @@ namespace Athena.Data.Tests.Repositories
             }
             
             Assert.Empty(await requirementRepository.GetPrereqsForCourseAsync(course));
+        }
+
+        [Theory, AutoData]
+        public async Task Prereq_ThrowsForDuplicate(Requirement prereq, Course course)
+        {
+            var requirementRepository = new RequirementRepository(_db);
+
+            await _institutions.AddAsync(course.Institution);
+            await _sut.AddAsync(course);
+            await requirementRepository.AddAsync(prereq);
+
+            await _sut.AddPrerequisiteAsync(course, prereq);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.AddPrerequisiteAsync(course, prereq));
         }
         
         [Theory, AutoData]
@@ -165,6 +193,20 @@ namespace Athena.Data.Tests.Repositories
         }
 
         [Theory, AutoData]
+        public async Task ConcurrentPrereq_ThrowsForDuplicate(Requirement prereq, Course course)
+        {
+            var requirementRepository = new RequirementRepository(_db);
+
+            await _institutions.AddAsync(course.Institution);
+            await _sut.AddAsync(course);
+            await requirementRepository.AddAsync(prereq);
+
+            await _sut.AddConcurrentPrerequisiteAsync(course, prereq);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.AddConcurrentPrerequisiteAsync(course, prereq));
+        }
+
+        [Theory, AutoData]
         public async Task TracksCompletedCoursesForStudent(List<Course> courses, Student student)
         {
             var studentRepo = new StudentRepository(_db);
@@ -188,6 +230,19 @@ namespace Athena.Data.Tests.Repositories
             }
             
             Assert.Empty(await _sut.GetCompletedCoursesForStudentAsync(student));
+        }
+
+        [Theory, AutoData]
+        public async Task CompletedCourses_ThrowsForDuplicate(Course course, Student student)
+        {
+            var studentRepo = new StudentRepository(_db);
+            await studentRepo.AddAsync(student);
+            await _institutions.AddAsync(course.Institution);
+            await _sut.AddAsync(course);
+            
+            await _sut.MarkCourseAsCompletedForStudentAsync(course, student);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.MarkCourseAsCompletedForStudentAsync(course, student));
         }
         
         [Theory, AutoData]
@@ -217,6 +272,19 @@ namespace Athena.Data.Tests.Repositories
         }
 
         [Theory, AutoData]
+        public async Task InProgressCourse_ThrowsForDuplicate(Course course, Student student)
+        {
+            var studentRepo = new StudentRepository(_db);
+            await studentRepo.AddAsync(student);
+            await _institutions.AddAsync(course.Institution);
+            await _sut.AddAsync(course);
+
+            await _sut.MarkCourseInProgressForStudentAsync(course, student);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.MarkCourseInProgressForStudentAsync(course, student));
+        }
+
+        [Theory, AutoData]
         public async Task TracksOfferings(List<Offering> offerings, Course course, Campus common)
         {
             var campusRepo = new CampusRepository(_db);
@@ -243,6 +311,22 @@ namespace Athena.Data.Tests.Repositories
             }
             
             Assert.Empty(await offeringRepo.GetOfferingsForCourseAsync(course));
+        }
+
+        [Theory, AutoData]
+        public async Task Offering_ThrowsForDuplicate(Offering offering, Course course)
+        {
+            var campusRepo = new CampusRepository(_db);
+            var offeringRepo = new OfferingRepository(_db);
+
+            await _institutions.AddAsync(course.Institution);
+            await _sut.AddAsync(course);
+            await campusRepo.AddAsync(offering.Campus);
+            await offeringRepo.AddAsync(offering);
+
+            await _sut.AddOfferingAsync(course, offering);
+            await Assert.ThrowsAsync<DuplicateObjectException>(
+                async () => await _sut.AddOfferingAsync(course, offering));
         }
     }
 }

--- a/test/Integration/Athena.Data.Tests/Repositories/InstitutionRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/InstitutionRepositoryTests.cs
@@ -103,5 +103,18 @@ namespace Athena.Data.Tests.Repositories
             
             Assert.Empty(await _sut.GetInstitutionsForStudentAsync(student));
         }
+
+        [Theory, AutoData]
+        public async Task Students_ThrowsForDuplicate(Institution institution, Student student)
+        {
+            var studentRepo = new StudentRepository(_db);
+
+            await studentRepo.AddAsync(student);
+            await _sut.AddAsync(institution);
+
+            await _sut.EnrollStudentAsync(institution, student);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.EnrollStudentAsync(institution, student));
+        }
     }
 }

--- a/test/Integration/Athena.Data.Tests/Repositories/MeetingRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/MeetingRepositoryTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Athena.Core.Exceptions;
 using Athena.Core.Models;
 using Athena.Data.Repositories;

--- a/test/Integration/Athena.Data.Tests/Repositories/OfferingRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/OfferingRepositoryTests.cs
@@ -90,5 +90,19 @@ namespace Athena.Data.Tests.Repositories
             
             Assert.Empty(await meetingRepo.GetMeetingsForOfferingAsync(offering));
         }
+
+        [Theory, AutoData]
+        public async Task Meeting_ThrowsForDuplicate(Meeting meeting, Offering offering)
+        {
+            var meetingRepo = new MeetingRepository(_db);
+
+            await _campuses.AddAsync(offering.Campus);
+            await _sut.AddAsync(offering);
+            await meetingRepo.AddAsync(meeting);
+
+            await _sut.AddMeetingAsync(offering, meeting);
+            await Assert.ThrowsAsync<DuplicateObjectException>(
+                async () => await _sut.AddMeetingAsync(offering, meeting));
+        }
     }
 }

--- a/test/Integration/Athena.Data.Tests/Repositories/ProgramRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/ProgramRepositoryTests.cs
@@ -113,5 +113,19 @@ namespace Athena.Data.Tests.Repositories
 
             Assert.Empty(await requirementRepository.GetRequirementsForProgramAsync(program));
         }
+
+        [Theory, AutoData]
+        public async Task Requirement_ThrowsForDuplicate(Requirement req, Program program)
+        {
+            var requirementRepository = new RequirementRepository(_db);
+            
+            await _instutitons.AddAsync(program.Institution);
+            await _sut.AddAsync(program);
+            await requirementRepository.AddAsync(req);
+
+            await _sut.AddRequirementAsync(program, req);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.AddRequirementAsync(program, req));
+        }
     }
 }

--- a/test/Integration/Athena.Data.Tests/Repositories/StudentRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/StudentRepositoryTests.cs
@@ -82,5 +82,20 @@ namespace Athena.Data.Tests.Repositories
             
             Assert.Empty(await programRepository.GetProgramsForStudentAsync(student));
         }
+
+        [Theory, AutoData]
+        public async Task Programs_ThrowsForDuplicate(Program program, Student student)
+        {
+            var institutionRepository = new InstitutionRepository(_db);
+            var programRepository = new ProgramRepository(_db);
+            
+            await institutionRepository.AddAsync(program.Institution);
+            await _sut.AddAsync(student);
+            await programRepository.AddAsync(program);
+
+            await _sut.RegisterForProgramAsync(student, program);
+            await Assert.ThrowsAsync<DuplicateObjectException>(async () =>
+                await _sut.RegisterForProgramAsync(student, program));
+        }
     }
 }


### PR DESCRIPTION
Previously, it was possible to insert duplicate rows into relationship tables. For example, a student could register for an institution multiple times and duplicate results would be shown when queried via the API. This PR does two things:

* Add a migration to drop any duplicate entries and add a unique constraint to prevent further duplicate entries
* Check for duplicate insertion at the API and throw `DuplicateObjectException` if attempted.

Fixes #47 