### PR TITLE
WebHost: Wait for the database to become ready before attempting to run migrations

### DIFF
--- a/src/Athena.Data/EnvironmentVariableConnectionStringProvider.cs
+++ b/src/Athena.Data/EnvironmentVariableConnectionStringProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Athena.Data
+{
+    public class EnvironmentVariableConnectionStringProvider : IConnectionStringProvider
+    {
+        public static readonly string DEFAULT_CONNECTION_STRING = "Server=localhost;User ID=postgres;Database=postgres";
+        public static readonly string CONNECTION_STRING_ENV = "ATHENA_CONNECTION_STRING";
+        
+        private static readonly Lazy<string> ConnectionString = new Lazy<string>(() =>
+            Environment.GetEnvironmentVariable(CONNECTION_STRING_ENV) ?? DEFAULT_CONNECTION_STRING
+        );
+
+        public string GetConnectionString() => ConnectionString.Value;
+    }
+}

--- a/src/Athena.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Athena.Data/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Data;
+﻿using System.Data;
 using Athena.Core.Models.Identity;
 using Athena.Core.Repositories;
 using Athena.Data.Repositories;
@@ -14,23 +13,10 @@ namespace Athena.Data.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-        public static readonly string DEFAULT_CONNECTION_STRING = "Server=localhost;User ID=postgres;Database=postgres";
-        public static readonly string CONNECTION_STRING_ENV = "ATHENA_CONNECTION_STRING";
-        
-        private static readonly Lazy<string> _connectionString = new Lazy<string>(() =>
-            Environment.GetEnvironmentVariable(CONNECTION_STRING_ENV) ?? DEFAULT_CONNECTION_STRING
-        );
-        
-        public static string ConnectionString => _connectionString.Value;
-        
         public static IServiceCollection AddAthenaRepositoriesUsingPostgres(this IServiceCollection services)
         {
-            if (string.IsNullOrEmpty(ConnectionString))
-            {
-                throw new ArgumentException("Connection string required", nameof(ConnectionString));
-            }
-            
-            services.AddScoped<IDbConnection>(s => new ProfiledDbConnection(new NpgsqlConnection(ConnectionString), MiniProfiler.Current));
+            services.AddSingleton<IConnectionStringProvider, EnvironmentVariableConnectionStringProvider>();
+            services.AddScoped<IDbConnection>(s => new ProfiledDbConnection(new NpgsqlConnection(s.GetRequiredService<IConnectionStringProvider>().GetConnectionString()), MiniProfiler.Current));
             
             services.AddScoped<ICampusRepository, CampusRepository>();
             services.AddScoped<ICourseRepository, CourseRepository>();

--- a/src/Athena.Data/IConnectionStringProvider.cs
+++ b/src/Athena.Data/IConnectionStringProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Athena.Data
+{
+    public interface IConnectionStringProvider
+    {
+        string GetConnectionString();
+    }
+}

--- a/src/Athena/Athena.csproj
+++ b/src/Athena/Athena.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.0.0-alpha9-00206" />
+    <PackageReference Include="Polly" Version="5.8.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
   </ItemGroup>

--- a/src/Athena/Setup/ApplicationBuilderExtensions.cs
+++ b/src/Athena/Setup/ApplicationBuilderExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using Athena.Core.Models;
 using Athena.Core.Models.Identity;
 using Athena.Core.Repositories;
+using Athena.Data;
 using Athena.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -12,6 +14,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Polly;
 using Serilog;
 
 namespace Athena.Setup
@@ -55,6 +58,9 @@ namespace Athena.Setup
             
             app.UseMvc();
 
+            app.WaitForDatabase();
+            app.EnsureMigrated();
+
             Task.Run(async () =>
             {
                 using (var scope = app.ApplicationServices.CreateScope())
@@ -95,6 +101,34 @@ namespace Athena.Setup
             }, CancellationToken.None).GetAwaiter().GetResult();
             
             return app;
+        }
+
+        private static void WaitForDatabase(this IApplicationBuilder app)
+        {
+            Policy.Handle<Exception>()
+                .WaitAndRetry(
+                    int.Parse(Environment.GetEnvironmentVariable("ATHENA_DB_RETRY_LIMIT") ?? "10"),
+                    attempt => TimeSpan.FromSeconds(Math.Min(0.1 * (2 << attempt), 10)),
+                    (ex, duration) => Log.Fatal("Database not ready due to {message}. Retrying in {duration}", ex.Message, duration)
+                ).Execute(() =>
+                {
+                    using (var scope = app.ApplicationServices.CreateScope())
+                    using (var db = scope.ServiceProvider.GetRequiredService<IDbConnection>())
+                    {
+                        db.Open();
+                        db.Close();
+                    }
+                });
+        }
+
+        private static void EnsureMigrated(this IApplicationBuilder app)
+        {
+            Log.Information("Ensuring database is migrated");
+            using (var scope = app.ApplicationServices.CreateScope())
+            {
+                var provider = scope.ServiceProvider.GetRequiredService<IConnectionStringProvider>();
+                new DatabaseMigrator(provider.GetConnectionString()).Migrate();
+            }
         }
     }
 }

--- a/src/Athena/Setup/Program.cs
+++ b/src/Athena/Setup/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Athena.Data;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Serilog;
@@ -14,9 +13,6 @@ namespace Athena.Setup
 
             try
             {
-                Log.Information("Ensuring database is migrated");
-                new DatabaseMigrator(Athena.Data.Extensions.ServiceCollectionExtensions.ConnectionString).Migrate();
-
                 Log.Information("Starting Web Host");
                 BuildWebHost(args).Run();
             }


### PR DESCRIPTION
We need to ensure the database is ready before we can run migrations or accept any requests. This makes the web host more graceful to stand up in a docker-compose environment or when debugging when you forget to start postgres.

Fixes #51 