### PR TITLE
Docker: Make a sample db with test data pre-loaded

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -210,6 +210,12 @@ Task("Docker::Build")
         Tag = new []{$"athenascheduler/importer:{imageTag}"},
         File = "./src/Athena.Importer/Dockerfile"
     }, ".");
+
+    DockerBuild(new DockerImageBuildSettings
+    {
+        Tag = new []{$"athenascheduler/db:{imageTag}"},
+        File = "./src/Athena.Importer/contrib/docker/Dockerfile"
+    }, ".");
 });
 
 Task("Docker::Push")

--- a/src/Athena.Importer/contrib/docker/Dockerfile
+++ b/src/Athena.Importer/contrib/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM microsoft/aspnetcore:2 AS importer
+
+ARG ADMIN_API_KEY=athena-sample
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-9.6 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /athena
+
+# You need to run 'docker build -f src/Athena.Importer/contrib/docker/Dockerfile .' from the solution root
+COPY ./_dist/Athena/ ./www
+COPY ./_dist/Athena.Importer/ ./importer
+COPY ./src/Athena.Importer/data/ ./importer/data
+COPY ./src/Athena.Importer/contrib/docker/import.sh ./
+
+ENV ASPNETCORE_URLS=http://0.0.0.0:5000
+RUN ./import.sh
+
+FROM postgres:alpine
+LABEL maintainer='Athena Developers'
+LABEL repo='https://github.com/athena-scheduler/athena'
+COPY --from=importer --chown=postgres:postgres /export.sql /docker-entrypoint-initdb.d/export.sql

--- a/src/Athena.Importer/contrib/docker/import.sh
+++ b/src/Athena.Importer/contrib/docker/import.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADMIN_API_KEY="${ADMIN_API_KEY:-athena-sample}"
+
+# Setup Database
+su -c '/usr/lib/postgresql/9.6/bin/initdb --username=postgres /var/lib/postgresql/data' postgres
+sed -i 's|^data_directory = .*$|data_directory = '\''/var/lib/postgresql/data'\''|g' /etc/postgresql/9.6/main/postgresql.conf
+sed -i -e 's/peer/trust/g' -e 's/md5/trust/g' /etc/postgresql/9.6/main/pg_hba.conf
+service postgresql start
+
+# Migrate and create admin account
+pushd /athena/www
+ATHENA_INIT_ONLY=1 dotnet ./Athena.dll
+
+# Reset admin api key
+psql -U postgres -c "UPDATE users SET api_key='${ADMIN_API_KEY}'"
+
+# Run API for importer
+dotnet ./Athena.dll &
+ATHENA_API_PID=$!
+popd
+
+# Run Importer
+pushd /athena/importer
+sleep 10
+dotnet ./Athena.Importer.dll --api-endpoint http://localhost:5000/api --data-path ./data --api-key "${ADMIN_API_KEY}"
+popd
+
+# Make an archive
+pg_dumpall -U postgres > /export.sql
+sed -i -e 's/CREATE ROLE postgres;//g' /export.sql
+
+# Cleanup
+kill $ATHENA_API_PID
+service postgresql stop

--- a/src/Athena/Setup/ApplicationBuilderExtensions.cs
+++ b/src/Athena/Setup/ApplicationBuilderExtensions.cs
@@ -99,6 +99,11 @@ namespace Athena.Setup
                 }
             }, CancellationToken.None).GetAwaiter().GetResult();
             
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ATHENA_INIT_ONLY")))
+            {
+                Environment.Exit(0);
+            }
+
             return app;
         }
 


### PR DESCRIPTION
This makes development easier. Instead of:

1. Starting a plain postgres container
2. Starting the API
3. Copying the default admin api key
4. Running the importer

You can now just

1. `docker run -it --rm -p 5432:5432 athenascheduler/db`

:tada:

I've already pushed an image if you want to play around with it without building. It should be automatically built and pushed whenever new commits land on master.