### PR TITLE
build: Push athenascheduler/db image in push task

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -224,6 +224,7 @@ Task("Docker::Push")
 {
     DockerPush($"athenascheduler/athena:{imageTag}");
     DockerPush($"athenascheduler/importer:{imageTag}");
+    DockerPush($"athenascheduler/db:{imageTag}");
 });
 
 Task("CodeCov::Publish")


### PR DESCRIPTION
We should probably push the `athenascheduler/db` image when we build it...

Fixes #71 