### PR TITLE
Prevent students from enrolling in courses with unmet dependencies

### DIFF
--- a/src/Athena.Core/Repositories/IRequirementRepository.cs
+++ b/src/Athena.Core/Repositories/IRequirementRepository.cs
@@ -50,5 +50,19 @@ namespace Athena.Core.Repositories
         /// and <see cref="IProgramRepository.RemoveRequirementAsync"/>
         /// </remarks>
         Task<IEnumerable<Requirement>> GetRequirementsForProgramAsync(Program program);
+
+        /// <summary>
+        /// Gets all requirements a student is currently taking
+        /// </summary>
+        /// <param name="student">The student to get requirements for</param>
+        /// <returns>A collection of all requirements the student is currently taking</returns>
+        Task<IEnumerable<Requirement>> GetInProgressRequirementsForStudentAsync(Student student);
+        
+        /// <summary>
+        /// Gets all requirements a student has completed
+        /// </summary>
+        /// <param name="student">The student to get requirements for</param>
+        /// <returns>A collection of all requirements the student has already completed</returns>
+        Task<IEnumerable<Requirement>> GetCompletedRequirementsForStudentAsync(Student student);
     }
 }

--- a/src/Athena.Data/Repositories/RequirementRepository.cs
+++ b/src/Athena.Data/Repositories/RequirementRepository.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Athena.Core.Models;
 using Athena.Core.Repositories;

--- a/src/Athena.Data/Repositories/RequirementRepository.cs
+++ b/src/Athena.Data/Repositories/RequirementRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Athena.Core.Models;
 using Athena.Core.Repositories;
@@ -84,6 +85,34 @@ namespace Athena.Data.Repositories
                         ON r.id = link.requirement
                 WHERE link.program = @id",
                 new {program.Id}
+            );
+
+        public async Task<IEnumerable<Requirement>> GetInProgressRequirementsForStudentAsync(Student student) =>
+            await _db.QueryAsync<Requirement>(@"
+                SELECT r.id,
+                       r.name,
+                       r.description
+                FROM requirements r
+                    LEFT JOIN course_requirements c
+                        ON r.id = c.requirement
+                    LEFT JOIN student_x_in_progress_course link
+                        ON c.course = link.course
+                WHERE link.student = @id",
+                new {student.Id}
+            );
+
+        public async Task<IEnumerable<Requirement>> GetCompletedRequirementsForStudentAsync(Student student) =>
+            await _db.QueryAsync<Requirement>(@"
+                SELECT r.id,
+                       r.name,
+                       r.description
+                FROM requirements r
+                    LEFT JOIN course_requirements c
+                        ON r.id = c.requirement
+                    LEFT JOIN student_x_completed_course link
+                        ON c.course = link.course
+                WHERE link.student = @id",
+                new {student.Id}
             );
     }
 }

--- a/src/Athena/Content/js/schedule.js
+++ b/src/Athena/Content/js/schedule.js
@@ -117,7 +117,7 @@ function setSearchResults(data) {
                             <div style="margin-bottom: 0.25rem">
                                 Unable to enroll in <span class="conflict-target" style="text-decoration: underline"></span>
                             </div>
-                            <div style="margin-bottom: 0.25rem">
+                            <div style="margin-bottom: 0.25rem">f
                                 As it conflicts with <span class="conflict-source" style="text-decoration: underline"></span>
                             </div>
                             <div style="margin-bottom: 0.25rem">
@@ -133,6 +133,26 @@ function setSearchResults(data) {
                         
                         Materialize.Toast.removeAll();
                         Materialize.toast(toastContent, 10000, 'amber darken-4 toast-wrap right');
+                    } else if (err.status === 412 && payload.details) {
+                        const modal = $('#unmet-dependency-error');
+                        
+                        modal.find('#unmet-target').text(payload.details.course.Name);
+                        
+                        const unmetConcurrentList = modal.find('#unmet-concurrent-list').html('');
+                        if (payload.details.unmetConcurrent.length > 0) {
+                            for (let r of payload.details.unmetConcurrent) {
+                                unmetConcurrentList.append($(`<li></li>`).text(r.Name + ' - ' + r.Description));
+                            }
+                        }
+                        
+                        const unmetList = modal.find('#unmet-list').html('');
+                        if (payload.details.unmet.length > 0) {
+                            for (let r of payload.details.unmet) {
+                                unmetList.append($(`<li></li>`).text(r.Name + ' - ' + r.Description));
+                            }
+                        }
+                        
+                        modal.modal('open');
                     }
                 }
             });

--- a/src/Athena/Content/js/schedule.js
+++ b/src/Athena/Content/js/schedule.js
@@ -117,7 +117,7 @@ function setSearchResults(data) {
                             <div style="margin-bottom: 0.25rem">
                                 Unable to enroll in <span class="conflict-target" style="text-decoration: underline"></span>
                             </div>
-                            <div style="margin-bottom: 0.25rem">f
+                            <div style="margin-bottom: 0.25rem">
                                 As it conflicts with <span class="conflict-source" style="text-decoration: underline"></span>
                             </div>
                             <div style="margin-bottom: 0.25rem">
@@ -132,7 +132,7 @@ function setSearchResults(data) {
                         toastContent.find('.conflict-dow').text(moment.weekdays()[payload.details.conflictingTimeSlot.Day]);
                         
                         Materialize.Toast.removeAll();
-                        Materialize.toast(toastContent, 10000, 'amber darken-4 toast-wrap right');
+                        Materialize.toast(toastContent, 10000, 'red darken-4 toast-wrap right');
                     } else if (err.status === 412 && payload.details) {
                         const modal = $('#unmet-dependency-error');
                         

--- a/src/Athena/Content/js/schedule.js
+++ b/src/Athena/Content/js/schedule.js
@@ -110,8 +110,8 @@ function setSearchResults(data) {
                     const payload = err.responseJSON;
                     if (err.status === 409 && payload.details)
                     {
-                        const start = timeSpanToMoment(payload.details.conflictingTimeSlot.start).format('h:mm A');
-                        const end   = timeSpanToMoment(payload.details.conflictingTimeSlot.end).format('h:mm A');
+                        const start = timeSpanToMoment(payload.details.conflictingTimeSlot.Time).format('h:mm A');
+                        const end   = timeSpanToMoment(payload.details.conflictingTimeSlot.End).format('h:mm A');
                         
                         const toastContent = $(`<div>
                             <div style="margin-bottom: 0.25rem">
@@ -129,7 +129,7 @@ function setSearchResults(data) {
                         toastContent.find('.conflict-source').text(payload.details.conflict.Course.Name);
                         toastContent.find('.conflict-time-start').text(start);
                         toastContent.find('.conflict-time-end').text(end);
-                        toastContent.find('.conflict-dow').text(moment.weekdays()[payload.details.conflictingTimeSlot.dow]);
+                        toastContent.find('.conflict-dow').text(moment.weekdays()[payload.details.conflictingTimeSlot.Day]);
                         
                         Materialize.Toast.removeAll();
                         Materialize.toast(toastContent, 10000, 'amber darken-4 toast-wrap right');

--- a/src/Athena/Controllers/api/StudentOfferingsController.cs
+++ b/src/Athena/Controllers/api/StudentOfferingsController.cs
@@ -13,14 +13,17 @@ namespace Athena.Controllers.api
     {
         private readonly IStudentRepository _students;
         private readonly IOfferingReository _offerings;
+        private readonly IRequirementRepository _requirements;
 
         public StudentOfferingsController(
             IStudentRepository students,
-            IOfferingReository offerings
+            IOfferingReository offerings,
+            IRequirementRepository requirements
         )
         {
             _students = students ?? throw new ArgumentNullException(nameof(students));
             _offerings = offerings ?? throw new ArgumentNullException(nameof(offerings));
+            _requirements = requirements ?? throw new ArgumentNullException(nameof(requirements));
         }
 
         [HttpGet]
@@ -38,7 +41,7 @@ namespace Athena.Controllers.api
             var offering = (await _offerings.GetAsync(offeringId)).NotFoundIfNull();
                 
             await offering.CheckForConflictingTimeSlots(student, _offerings);
-            
+            await offering.CheckForMetPrerequisites(student, _requirements);
 
             await _offerings.EnrollStudentInOfferingAsync(student, offering);
         }

--- a/src/Athena/Controllers/api/StudentOfferingsController.cs
+++ b/src/Athena/Controllers/api/StudentOfferingsController.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Athena.Core.Models;
 using Athena.Core.Repositories;
-using Athena.Exceptions;
 using Athena.Extensions;
 using Microsoft.AspNetCore.Mvc;
 
@@ -39,31 +36,9 @@ namespace Athena.Controllers.api
         {
             var student = (await _students.GetAsync(id)).NotFoundIfNull();
             var offering = (await _offerings.GetAsync(offeringId)).NotFoundIfNull();
-
-            foreach (var inProgressOffering in await _offerings.GetInProgressOfferingsForStudentAsync(student))
-            {
-                foreach (var inProgressMeeting in inProgressOffering.Meetings)
-                {
-                    // Clever solutin from https://stackoverflow.com/a/13513973/8723823
-                    if (offering.Meetings.Any(m => m.Day == inProgressMeeting.Day && inProgressMeeting.Time < m.End && m.Time < inProgressMeeting.End))
-                    {
-                        throw new ApiException(
-                            HttpStatusCode.Conflict,
-                            "Requested offering conflicts with an in-progress offering",
-                            new
-                            {
-                                conflict = inProgressOffering,
-                                conflictingTimeSlot = new
-                                {
-                                    dow = inProgressMeeting.Day,
-                                    start = inProgressMeeting.Time,
-                                    end = inProgressMeeting.End
-                                }
-                            }
-                        );
-                    }
-                }
-            }
+                
+            await offering.CheckForConflictingTimeSlots(student, _offerings);
+            
 
             await _offerings.EnrollStudentInOfferingAsync(student, offering);
         }

--- a/src/Athena/Exceptions/BadModelException.cs
+++ b/src/Athena/Exceptions/BadModelException.cs
@@ -1,12 +1,19 @@
-﻿using System;
+﻿using System.Linq;
+using System.Net;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Athena.Exceptions
 {
-    public class BadModelException : ArgumentException
+    public class BadModelException : ApiException
     {
         public readonly ModelStateDictionary ModelState;
 
-        public BadModelException(ModelStateDictionary state) => ModelState = state;
+        public BadModelException(ModelStateDictionary state) : base(
+            HttpStatusCode.BadRequest,
+            "Validation of one or more parameters failed",
+            state.Keys.Select(
+                k => new {Key = k, Error = state[k].Errors.Select(er => er.ErrorMessage)}
+            ).ToDictionary(k => k.Key, v => v.Error)
+        ) => ModelState = state;
     }
 }

--- a/src/Athena/Exceptions/OfferingConflictException.cs
+++ b/src/Athena/Exceptions/OfferingConflictException.cs
@@ -1,0 +1,17 @@
+﻿using System.Net;
+using Athena.Core.Models;
+
+namespace Athena.Exceptions
+{
+    public class OfferingConflictException : ApiException
+    {
+        public OfferingConflictException(Offering conflict, Meeting conflictingTimeSlot)
+            : base(HttpStatusCode.Conflict, "Requested offering conflicts with an in-progress offering", new
+            {
+                conflict,
+                conflictingTimeSlot
+            })
+        {
+        }
+    }
+}

--- a/src/Athena/Exceptions/UnmetDependencyException.cs
+++ b/src/Athena/Exceptions/UnmetDependencyException.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using Athena.Core.Models;
+using Athena.Models;
+
+namespace Athena.Exceptions
+{
+    public class UnmetDependencyException : ApiException
+    {
+        public UnmetDependencyException(Course course, List<Requirement> unmet, List<Requirement> unmetConcurrent)
+            : base(
+                HttpStatusCode.PreconditionFailed,
+                "Attempted to enroll in a course without meeting all requirement conditions",
+                new
+                {
+                    course,
+                    unmet,
+                    unmetConcurrent
+                }
+            )
+        {
+        }
+    }
+}

--- a/src/Athena/Extensions/EnumerableExtensions.cs
+++ b/src/Athena/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,4 @@
+﻿$HEADER$namespace $NAMESPACE$
+{
+  public class $CLASS$ {$END$}
+}

--- a/src/Athena/Extensions/EnumerableExtensions.cs
+++ b/src/Athena/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,27 @@
-﻿$HEADER$namespace $NAMESPACE$
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Athena.Core.Models;
+using Athena.Core.Repositories;
+using Athena.Exceptions;
+
+namespace Athena.Extensions
 {
-  public class $CLASS$ {$END$}
+    public static class EnumerableExtensions
+    {
+        public static async Task CheckForConflictingTimeSlots(this Offering offering, Student student, IOfferingReository _offerings)
+        {
+            foreach (var inProgressOffering in await _offerings.GetInProgressOfferingsForStudentAsync(student))
+            {
+                foreach (var inProgressMeeting in inProgressOffering.Meetings)
+                {
+                    // Clever solutin from https://stackoverflow.com/a/13513973/8723823
+                    if (offering.Meetings.Any(m => m.Day == inProgressMeeting.Day && inProgressMeeting.Time < m.End && m.Time < inProgressMeeting.End))
+                    {
+                        throw new OfferingConflictException(inProgressOffering, inProgressMeeting);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/Athena/Middleware/CustomErrorHandlerMiddleware.cs
+++ b/src/Athena/Middleware/CustomErrorHandlerMiddleware.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-using System.Net;
-using System.Runtime.InteropServices.ComTypes;
+﻿using System.Net;
 using System.Threading.Tasks;
 using Athena.Core.Exceptions;
 using Athena.Exceptions;
@@ -20,17 +18,6 @@ namespace Athena.Middleware
             try
             {
                 await _next(ctx);
-            }
-            catch (BadModelException e)
-            {
-                ctx.Response.StatusCode = (int) HttpStatusCode.BadRequest;
-                ctx.Response.ContentType = "application/json";
-
-                await ctx.Response.WriteAsync(JsonConvert.SerializeObject(
-                    e.ModelState.Keys.Select(
-                        k => new {Key = k, Error = e.ModelState[k].Errors.Select(er => er.ErrorMessage)}
-                    ).ToDictionary(k => k.Key, v => v.Error)
-                ));
             }
             catch (DuplicateObjectException e)
             {

--- a/src/Athena/Views/Schedule/ScheduleEditor.cshtml
+++ b/src/Athena/Views/Schedule/ScheduleEditor.cshtml
@@ -15,6 +15,7 @@
     @Html.Partial("_CurrentSchedule", false)
 </div>
 @Html.Partial("_CurrentScheduleModal", false)
+@Html.Partial("_UnmetDependencyError")
 
 @section Scripts
 {

--- a/src/Athena/Views/Schedule/_UnmetDependencyError.cshtml
+++ b/src/Athena/Views/Schedule/_UnmetDependencyError.cshtml
@@ -1,0 +1,14 @@
+﻿<div id="unmet-dependency-error" class="modal">
+    <div class="modal-content">
+        <h4>Unable to enroll in Course</h4>
+        <p>
+            We can't enroll you in <span id="unmet-target"></span> because you haven't taken some of
+            its dependencies:
+        </p>
+        <ul id="unmet-concurrent-list" class="browser-default"></ul>
+        <ul id="unmet-list" class="browser-default"></ul>
+    </div>
+    <div class="modal-footer">
+        <a href="#" class="modal-action modal-close btn-flat">OK</a>
+    </div>
+</div>

--- a/test/Integration/Athena.Data.Tests/Repositories/RequirementRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/RequirementRepositoryTests.cs
@@ -1,7 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Athena.Core.Exceptions;
 using Athena.Core.Models;
+using Athena.Core.Models.Identity;
 using Athena.Data.Repositories;
+using Athena.Data.Repositories.Identity;
 using AutoFixture.Xunit2;
 using Xunit;
 
@@ -51,6 +56,105 @@ namespace Athena.Data.Tests.Repositories
 
             await _sut.DeleteAsync(requirement);
             Assert.Null(await _sut.GetAsync(requirement.Id));
+        }
+
+        [Theory, AutoData]
+        public async Task GetInProgressRequirementsValid(
+            Dictionary<Offering, List<Requirement>> testData,
+            KeyValuePair<Offering, List<Requirement>> exclude,
+            AthenaUser user)
+        {
+            var campuses = new CampusRepository(_db);
+            var courses = new CourseRepository(_db);
+            var institutions = new InstitutionRepository(_db);
+            var meetings = new MeetingRepository(_db);
+            var offerings = new OfferingRepository(_db, meetings);
+            var userRepo = new AthenaUserStore(_db);
+            var studentRepo = new StudentRepository(_db);
+
+            user.Student.Id = user.Id;
+            await studentRepo.AddAsync(user.Student);
+            await userRepo.CreateAsync(user, CancellationToken.None);
+
+
+            foreach (var (offering, reqs) in testData.Union(new [] { exclude }))
+            {
+                await campuses.AddAsync(offering.Campus);
+                await institutions.AddAsync(offering.Course.Institution);
+                await courses.AddAsync(offering.Course);
+                await offerings.AddAsync(offering);
+                foreach (var meeting in offering.Meetings)
+                {
+                    meeting.Offering = offering.Id;
+                    await meetings.AddAsync(meeting);
+                }
+
+                foreach (var req in reqs)
+                {
+                    await _sut.AddAsync(req);
+                    await courses.AddSatisfiedRequirementAsync(offering.Course, req);
+                }
+            }
+
+            foreach (var offering in testData.Keys)
+            {
+                await offerings.EnrollStudentInOfferingAsync(user.Student, offering);
+            }
+
+            var expected = testData.Values.SelectMany(r => r).ToList();
+            var results = (await _sut.GetInProgressRequirementsForStudentAsync(user.Student)).ToList();
+            
+            Assert.Equal(expected.Count, results.Count);
+            Assert.All(expected, r => Assert.Contains(r, results));
+        }
+        
+        [Theory, AutoData]
+        public async Task GetCompletedRequirementsValid(
+            Dictionary<Offering, List<Requirement>> testData,
+            KeyValuePair<Offering, List<Requirement>> exclude,
+            AthenaUser user)
+        {
+            var campuses = new CampusRepository(_db);
+            var courses = new CourseRepository(_db);
+            var institutions = new InstitutionRepository(_db);
+            var meetings = new MeetingRepository(_db);
+            var offerings = new OfferingRepository(_db, meetings);
+            var userRepo = new AthenaUserStore(_db);
+            var studentRepo = new StudentRepository(_db);
+
+            user.Student.Id = user.Id;
+            await studentRepo.AddAsync(user.Student);
+            await userRepo.CreateAsync(user, CancellationToken.None);
+            
+            foreach (var (offering, reqs) in testData.Union(new [] { exclude }))
+            {
+                await campuses.AddAsync(offering.Campus);
+                await institutions.AddAsync(offering.Course.Institution);
+                await courses.AddAsync(offering.Course);
+                await offerings.AddAsync(offering);
+                foreach (var meeting in offering.Meetings)
+                {
+                    meeting.Offering = offering.Id;
+                    await meetings.AddAsync(meeting);
+                }
+
+                foreach (var req in reqs)
+                {
+                    await _sut.AddAsync(req);
+                    await courses.AddSatisfiedRequirementAsync(offering.Course, req);
+                }
+            }
+
+            foreach (var offering in testData.Keys)
+            {
+                await courses.MarkCourseAsCompletedForStudentAsync(offering.Course, user.Student);
+            }
+
+            var expected = testData.Values.SelectMany(r => r).ToList();
+            var results = (await _sut.GetCompletedRequirementsForStudentAsync(user.Student)).ToList();
+            
+            Assert.Equal(expected.Count, results.Count);
+            Assert.All(expected, r => Assert.Contains(r, results));
         }
     }
 }


### PR DESCRIPTION
We shouldn't enroll students in courses where they are missing dependent classes. We now show a warning dialog on the scheduler page with a list of direct requirements that are unmet.

Note that we do not follow this chain recursively since we can't easily get requirements of requirements. Personally I think this is fine. There's a potential solution I can think of that involves constructing a graph, finding leaf nodes, and culling nodes when they are completed, but that's non-trivial to implement in the time we have left.

I'm also looking for input on the wording of the dialog, let me know of something doesn't make sense or if things need more clarification. Specifically: Should we make a distinction in the dialog between purely unmet dependencies and unmet dependencies that can be taken concurrently, or leave it as is? It's two separate lists already so it's  not too big of a change to make.

Fixes #82 