### PR TITLE
Prevent courses registering requirements as both prereqs and concurent prereqs

### DIFF
--- a/src/Athena.Core/Exceptions/IllegalPrerequisiteException.cs
+++ b/src/Athena.Core/Exceptions/IllegalPrerequisiteException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Athena.Core.Models;
+
+namespace Athena.Core.Exceptions
+{
+    public class IllegalPrerequisiteException : ArgumentException
+    {
+        public readonly Course Course;
+        public readonly Requirement Prereq;
+
+        public IllegalPrerequisiteException(Course course, Requirement prereq) :
+            base("A requirement cannot be both a prerequisite and a concurrent prerequisite")
+        {
+            Course = course;
+            Prereq = prereq;
+        }
+    }
+}

--- a/src/Athena.Data/Migrations/20180412163557_EnsureConcurrentPrereqsAreNotRegularPrereqs.cs
+++ b/src/Athena.Data/Migrations/20180412163557_EnsureConcurrentPrereqsAreNotRegularPrereqs.cs
@@ -1,0 +1,11 @@
+using SimpleMigrations;
+namespace Athena.Data.Migrations
+{
+    [Migration(20180412163557, "EnsureConcurrentPrereqsAreNotRegularPrereqs")]
+    public class EnsureConcurrentPrereqsAreNotRegularPrereqs : ScriptMigration
+    {
+        public EnsureConcurrentPrereqsAreNotRegularPrereqs() : base("20180412163557_EnsureConcurrentPrereqsAreNotRegularPrereqs.sql")
+        {
+        }
+    }
+}

--- a/src/Athena.Data/Migrations/src/20180412163557_EnsureConcurrentPrereqsAreNotRegularPrereqs.sql
+++ b/src/Athena.Data/Migrations/src/20180412163557_EnsureConcurrentPrereqsAreNotRegularPrereqs.sql
@@ -1,0 +1,3 @@
+DELETE FROM course_prereqs prereqs
+USING course_concurrent_prereqs concurrents
+WHERE prereqs.course = concurrents.course AND prereqs.prereq = concurrents.prereq;

--- a/test/Integration/Athena.Data.Tests/Repositories/MeetingRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/MeetingRepositoryTests.cs
@@ -21,7 +21,7 @@ namespace Athena.Data.Tests.Repositories
         {
             _institutions = new InstitutionRepository(_db);
             _campuses = new CampusRepository(_db);
-            _courses = new CourseRepository(_db);
+            _courses = new CourseRepository(_db, new RequirementRepository(_db));
             _sut = new MeetingRepository(_db);
             _offerings = new OfferingRepository(_db, _sut);
         }

--- a/test/Integration/Athena.Data.Tests/Repositories/OfferingRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/OfferingRepositoryTests.cs
@@ -23,7 +23,7 @@ namespace Athena.Data.Tests.Repositories
         public OfferingRepositoryTests()
         {
             _campuses = new CampusRepository(_db);
-            _courses = new CourseRepository(_db);
+            _courses = new CourseRepository(_db, new RequirementRepository(_db));
             _institutions = new InstitutionRepository(_db);
             _meetings = new MeetingRepository(_db);
             _sut = new OfferingRepository(_db, _meetings);

--- a/test/Integration/Athena.Data.Tests/Repositories/RequirementRepositoryTests.cs
+++ b/test/Integration/Athena.Data.Tests/Repositories/RequirementRepositoryTests.cs
@@ -65,7 +65,7 @@ namespace Athena.Data.Tests.Repositories
             AthenaUser user)
         {
             var campuses = new CampusRepository(_db);
-            var courses = new CourseRepository(_db);
+            var courses = new CourseRepository(_db, _sut);
             var institutions = new InstitutionRepository(_db);
             var meetings = new MeetingRepository(_db);
             var offerings = new OfferingRepository(_db, meetings);
@@ -115,7 +115,7 @@ namespace Athena.Data.Tests.Repositories
             AthenaUser user)
         {
             var campuses = new CampusRepository(_db);
-            var courses = new CourseRepository(_db);
+            var courses = new CourseRepository(_db, _sut);
             var institutions = new InstitutionRepository(_db);
             var meetings = new MeetingRepository(_db);
             var offerings = new OfferingRepository(_db, meetings);


### PR DESCRIPTION
So this isn't exactly what was going on in #104 listing requirements twice but I know the fix for that and created #105 to fix that. The changes in this PR however definitely need to be made though in case someone ***does*** try to register a requirement as both a prereq and concurrent prereq.

Fixes #102 