### PR TITLE
Fix duplicate entries in unmet dependency warnings

### DIFF
--- a/src/Athena/Content/js/schedule.js
+++ b/src/Athena/Content/js/schedule.js
@@ -138,18 +138,27 @@ function setSearchResults(data) {
                         
                         modal.find('#unmet-target').text(payload.details.course.Name);
                         
-                        const unmetConcurrentList = modal.find('#unmet-concurrent-list').html('');
+                        const unmetConcurrentContainer = modal.find('#unmet-concurrent-container').html('');
                         if (payload.details.unmetConcurrent.length > 0) {
+                            const unmetConcurrentList = $('<ul class="browser-default"></ul>');
                             for (let r of payload.details.unmetConcurrent) {
                                 unmetConcurrentList.append($(`<li></li>`).text(r.Name + ' - ' + r.Description));
                             }
+                            
+                            unmetConcurrentContainer.append($(`<h5>May be taken concurrently:</h5>`));
+                            unmetConcurrentContainer.append(unmetConcurrentList);
                         }
                         
-                        const unmetList = modal.find('#unmet-list').html('');
+                        const unmetContainer = modal.find('#unmet-container').html('');
                         if (payload.details.unmet.length > 0) {
+                            const unmetList = $('<ul class="browser-default"></ul>');
+
                             for (let r of payload.details.unmet) {
                                 unmetList.append($(`<li></li>`).text(r.Name + ' - ' + r.Description));
                             }
+                            
+                            unmetContainer.append($(`<h5>Must be taken first:</h5>`));
+                            unmetContainer.append(unmetList);
                         }
                         
                         modal.modal('open');

--- a/src/Athena/Extensions/EnumerableExtensions.cs
+++ b/src/Athena/Extensions/EnumerableExtensions.cs
@@ -9,9 +9,9 @@ namespace Athena.Extensions
 {
     public static class EnumerableExtensions
     {
-        public static async Task CheckForConflictingTimeSlots(this Offering offering, Student student, IOfferingReository _offerings)
+        public static async Task CheckForConflictingTimeSlots(this Offering offering, Student student, IOfferingReository offerings)
         {
-            foreach (var inProgressOffering in await _offerings.GetInProgressOfferingsForStudentAsync(student))
+            foreach (var inProgressOffering in await offerings.GetInProgressOfferingsForStudentAsync(student))
             {
                 foreach (var inProgressMeeting in inProgressOffering.Meetings)
                 {
@@ -33,8 +33,7 @@ namespace Athena.Extensions
             var inProgress = (await requirements.GetInProgressRequirementsForStudentAsync(student)).ToList();
 
             var unmet = required.Where(r => !taken.Contains(r)).ToList();
-            var unmetConcurrent = required.Union(concurrent).Where(r => !taken.Contains(r) && !inProgress.Contains(r))
-                .ToList();
+            var unmetConcurrent = concurrent.Where(r => !taken.Contains(r) && !inProgress.Contains(r)).ToList();
 
             if (unmet.Count + unmetConcurrent.Count != 0)
             {

--- a/src/Athena/Views/Schedule/_UnmetDependencyError.cshtml
+++ b/src/Athena/Views/Schedule/_UnmetDependencyError.cshtml
@@ -2,11 +2,15 @@
     <div class="modal-content">
         <h4>Unable to enroll in Course</h4>
         <p>
-            We can't enroll you in <span id="unmet-target"></span> because you haven't taken some of
-            its dependencies:
+            We can't enroll you in <span id="unmet-target"></span> because you haven't taken any courses that
+            meet some of its dependencies:
         </p>
-        <ul id="unmet-concurrent-list" class="browser-default"></ul>
-        <ul id="unmet-list" class="browser-default"></ul>
+        <div id="unmet-concurrent-container">
+            
+        </div>
+        <div id="unmet-container">
+            
+        </div>
     </div>
     <div class="modal-footer">
         <a href="#" class="modal-action modal-close btn-flat">OK</a>


### PR DESCRIPTION
Previously, unmet dependencies might be duplicated in the warning popup. This fixes that, and adds section headers for unmet prereqs.

Fixes #105 