### PR TITLE
Update docker-compose example and add documentation for it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 _dist/
 _tests/
+auth-keys.env
 
 # MiniCover
 *coverage*

--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@
 
 A tool for assisting students with scheduling for courses.
 
+## Usage
+
+The easiest way to run the scheduler is via docker. This repository contains an example `docker-compose`
+file which is based off of [sample data](src/Athena.Importer/data/). If you want to enable authentication
+from external login providers (which you will need to do in order to do anything useful), copy `auth-keys.env.sample`
+to `auth-keys.env` and supply your google or microsoft OAuth2 keys:
+
+```bash
+cp auth-keys.env.sample auth-keys.env
+# Edit auth-keys.env to use your keys
+
+docker-compose pull
+docker-compose up
+```
+
+The web interface is now accessible at http://localhost:5000/. The API is on `/api` and the default admin
+api key for this sample data is `athena-sample`. Feel free to import more data.
+
+If you want to start from scratch, stand up a postgres 9.6 database and change the connection string in
+`docker-compose.yml` appropriately.
+
 ## Building
 
 Invoke the build build script:

--- a/auth-keys.env.sample
+++ b/auth-keys.env.sample
@@ -1,0 +1,9 @@
+# Required for Google Authentication
+# See https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/google-logins?tabs=aspnetcore2x#create-the-app-in-google-api-console
+AUTH_GOOGLE_CLIENT_KEY=
+AUTH_GOOGLE_CLIENT_SECRET=
+
+# Required for Microsoft Authentication
+# See https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/microsoft-logins?tabs=aspnetcore2x
+AUTH_MICROSOFT_CLIENT_KEY=
+AUTH_MICROSOFT_CLIENT_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,14 @@
 version: '3'
 services:
   athena:
-    build: '.'
+    image: athenascheduler/athena
     ports:
       - "5000:5000"
     environment:
       - "ATHENA_CONNECTION_STRING=Server=db;User ID=postgres;Database=postgres"
-      # - AUTH_GOOGLE_CLIENT_KEY=...
-      # - AUTH_GOOGLE_CLIENT_SECRET=...
+    env_file:
+      - auth-keys.env
     depends_on:
       - db
-    command:
-      - /contrib/wait-postgres.sh
-      - db
   db:
-    image: postgres:alpine
+    image: athenascheduler/db


### PR DESCRIPTION
We can use this in our presentation. Basically I updated the `docker-compose` sample to pull the official athena image and the sample data db image. It will now read auth keys from an environment file as well. This is all explained in the README.