### PR TITLE
Schedule: Wire up print button

### DIFF
--- a/src/Athena/Content/css/print.css
+++ b/src/Athena/Content/css/print.css
@@ -1,0 +1,10 @@
+@import '~fullcalendar/dist/fullcalendar.css';
+
+.fc-event, .fc-event-dot {
+    background-color: white;
+}
+
+.fc-event {
+    border-color: black;
+    color: black;
+}

--- a/src/Athena/Content/js/schedule.js
+++ b/src/Athena/Content/js/schedule.js
@@ -17,7 +17,9 @@ const offeringColors = [
 
 let nextColor = 0;
 
+let isFirstLoad = true;
 let searchTimeout = null;
+let loadedCallback = null;
 
 let calendar = null;
 let studentId = null;
@@ -49,6 +51,13 @@ function reloadSchedule() {
                 }
                 
                 self.calendar.renderEvent(ev, false);
+            }
+            
+            if (isFirstLoad) {
+                isFirstLoad = false;
+                if (loadedCallback) {
+                    loadedCallback();
+                }
             }
         })
         .fail(function (err) {
@@ -230,6 +239,10 @@ export function completeSchedule() {
         });
 }
 
+export function setLoadedCallback(cb) {
+    loadedCallback = cb;
+}
+
 export function init(studentId, readOnly) {
     self.studentId = studentId;
     self.isReadOnly = readOnly;
@@ -239,7 +252,7 @@ export function init(studentId, readOnly) {
     const calendarDiv = $('#calendar');
 
     function makeRemoveButton(event) {
-        return $(`<span class="right hidden-print"><i class="material-icons red-text text-accent-1" style="font-size: 16px;">close</i></span>`)
+        return $(`<span class="right"><i class="material-icons red-text text-accent-1" style="font-size: 16px;">close</i></span>`)
             .click(function () {
                 $.ajax({
                     url: apiRoot + '/student/' + self.studentId + '/offerings/' + event.offeringId,

--- a/src/Athena/Content/js/site.js
+++ b/src/Athena/Content/js/site.js
@@ -1,8 +1,2 @@
 ﻿import 'jquery';
 import 'materialize-css';
-
-$(function () {
-    $('.print-trigger').click(function () {
-       window.print(); 
-    });
-});

--- a/src/Athena/Controllers/ScheduleController.cs
+++ b/src/Athena/Controllers/ScheduleController.cs
@@ -5,6 +5,11 @@ namespace Athena.Controllers
     [Route("[controller]")]
     public class ScheduleController : AthenaControllerBase
     {
+        [HttpGet]
         public IActionResult ScheduleEditor() => View();
+
+        [HttpGet("print")]
+        public IActionResult PrintSchedule() => View();
+
     }
 }

--- a/src/Athena/Views/Schedule/PrintSchedule.cshtml
+++ b/src/Athena/Views/Schedule/PrintSchedule.cshtml
@@ -1,0 +1,36 @@
+﻿@{
+    Layout = null;
+    var student = User.ToAthenaUser();
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Print Schedule - Athena</title>
+
+    <link rel="stylesheet" href="@Url.Content("~/print.css")" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+</head>
+<body>
+<h2>@User.GetStudent().Name - Schedule</h2>
+<div id="calendar" style="height: 8in !important; width: 8in !important"></div>
+
+
+<script type="text/javascript" src="@Url.Content("~/athena.js")"></script>
+<script type="text/javascript" src="@Url.Content("~/schedule.js")"></script>
+<script type="text/javascript">
+    const apiRoot = "@Url.Content("~/api/v1")";
+
+    $(function() {
+        athena.schedule.setLoadedCallback(function() {
+            $('.material-tooltip').remove();
+            window.print();
+            setTimeout(window.close, 200);
+        });
+        athena.schedule.init('@(student.Id)', true);
+    });
+</script>
+</body>
+</html>

--- a/src/Athena/Views/Shared/_Layout.cshtml
+++ b/src/Athena/Views/Shared/_Layout.cshtml
@@ -41,7 +41,14 @@
 <script type="text/javascript" src="@Url.Content("~/athena.js")"></script>
 <script type="text/javascript">
     const apiRoot = "@Url.Content("~/api/v1")";
-    $('.modal').modal();
+    $(function () {
+        $('.modal').modal();
+        $('.print-trigger').click(function () {
+            window.open("@Url.Action(nameof(ScheduleController.PrintSchedule), "Schedule")",
+                'window',
+                'toolbar=no, menubar=no, resizable=yes');
+        });
+    });
 </script>
 
 <profile name="RenderScripts">

--- a/src/Athena/webpack.common.js
+++ b/src/Athena/webpack.common.js
@@ -11,7 +11,8 @@ module.exports = {
         athena: './bundle.js',
         studentSetup: './Content/js/studentSetup.js',
         schedule: './Content/js/schedule.js',
-        completedCourses: './Content/js/ConfigureCompletedCourses.js'
+        completedCourses: './Content/js/ConfigureCompletedCourses.js',
+        print: './Content/css/print.css'
     },
     output: {
         filename: "[name].js",


### PR DESCRIPTION
This is the best I think we're going to be able to do in the time
we have left. Something in materialize doesn't play nice with
fullcalendar such that whenever the window gets rendered in print
mode events aren't moved even though the calendar is, which makes
them off (sometimes by minutes, sometimes by hours). It's not even
linear.

To compromise, I'm rendering the print in a separate page that only
includes the fullcalendar stylesheet and a few other tweaks. This
means that compared to the rest of the site it looks fugly and there
is no color, but given that most students probably only have access
to a B/W printer I think this is probably fine. They're not looking
at this outside of bringing it with them when they go to schedule
classes anyways.

![screenshot from 2018-04-15 20-57-34](https://user-images.githubusercontent.com/794251/38785607-ae53a746-40ef-11e8-91d7-ca28c6ded80f.png)

Fixes: #97