### PR TITLE
Add close button to search modal

### DIFF
--- a/src/Athena/Views/Shared/_CurrentScheduleModal.cshtml
+++ b/src/Athena/Views/Shared/_CurrentScheduleModal.cshtml
@@ -16,10 +16,13 @@
     <div id="add-courses" class="modal bottom-sheet">
         <div class="modal-content">
             <div class="row">
-                <div class="input-field col s12">
+                <div class="input-field col s11">
                     <i class="material-icons prefix">search</i>
                     <input type="text" class="flow-text" id="course-search" />
                     <label for="course-search">Search</label>
+                </div>
+                <div class="input-field col s1">
+                    <a href="#" class="modal-action modal-close btn-flat"><i class="material-icons">close</i></a>
                 </div>
             </div>
             <div class="row" id="course-search-results"></div>


### PR DESCRIPTION
Add a close button to the course search modal for people who don't know that you can close the modal by clicking anywhere else or pressing escape.

Fixes #137 