### PR TITLE
Redirect client side if the user's session expires

### DIFF
--- a/src/Athena/Content/js/ConfigureCompletedCourses.js
+++ b/src/Athena/Content/js/ConfigureCompletedCourses.js
@@ -37,7 +37,8 @@ function markNotComplete(courseId) {
     $.ajax({
         url: apiRoot + '/student/' + self.StudentId + '/courses/completed/' + courseId,
         type: 'DELETE',
-        complete: fetchCompletedCourses
+        complete: fetchCompletedCourses,
+        error: checkExpiredSession
     });
 }
 
@@ -48,7 +49,8 @@ function markCourseComplete(courseId) {
         complete: function () {
             fetchCompletedCourses();
             doIncompleteSearch();
-        }
+        },
+        error: checkExpiredSession
     })
 }
 
@@ -111,6 +113,7 @@ function fetchCompletedCourses() {
             setCompletedCourses(data);
         })
         .fail(function (err) {
+            checkExpiredSession(err);
             console.error("broke: ", err)
         });
 }
@@ -122,6 +125,7 @@ function fetchIncompleteCourses() {
             setIncompleteCourses(data);
         })
         .fail(function (err) {
+            checkExpiredSession(err);
             console.error("broke: ", err)
         });
 }
@@ -137,10 +141,11 @@ function doIncompleteSearch() {
         url: apiRoot + '/student/' + self.StudentId + '/courses/incomplete',
         data: { query: q }
     }).done(setIncompleteCourses)
-        .fail(function (data) {
-            setIncompleteCourses([]);
-            console.error("Failed to search courses");
-        });
+      .fail(function (err) {
+          checkExpiredSession(err);
+          setIncompleteCourses([]);
+          console.error("Failed to search courses");
+      });
 }
 
 export function init(studentId) {
@@ -166,10 +171,11 @@ export function init(studentId) {
                         url: apiRoot + '/student/' + self.StudentId + '/courses/completed',
                         data: { query: q }
                     }).done(setCompletedCourses)
-                        .fail(function (data) {
-                            setCompletedCourses([]);
-                            console.error("Failed to search courses");
-                        });
+                      .fail(function (err) {
+                          checkExpiredSession(err);
+                          setCompletedCourses([]);
+                          console.error("Failed to search courses");
+                      });
                 },
                 250
             );

--- a/src/Athena/Content/js/schedule.js
+++ b/src/Athena/Content/js/schedule.js
@@ -61,6 +61,7 @@ function reloadSchedule() {
             }
         })
         .fail(function (err) {
+            checkExpiredSession(err);
             console.error(err);
             $("#complete-courses-trigger").prop("disabled", true);
             window.Materialize.toast('Failed to load enrolled courses', 3000, 'red darken-4');
@@ -138,6 +139,8 @@ function setSearchResults(data) {
                         utils.focusInput('#course-search');
                     },
                     error: function (err) {
+                        checkExpiredSession(err);
+                        
                         const payload = err.responseJSON;
                         if (err.status === 409 && payload.details)
                         {
@@ -225,10 +228,11 @@ function doSearch() {
                 url: apiRoot + '/student/' + self.studentId + '/schedule/offerings/available',
                 data: { q: q }
             }).done(setSearchResults)
-            .fail(function () {
-                setSearchResults([]);
-                console.error("Failed to search for completed courses")
-            })
+              .fail(function (err) {
+                  checkExpiredSession(err);
+                  setSearchResults([]);
+                  console.error("Failed to search for completed courses")
+              })
         },
         250
     );
@@ -249,7 +253,8 @@ export function render() {
 export function completeSchedule() {
     $.get(apiRoot + '/student/' + self.studentId + '/schedule/complete')
         .done(reloadAll)
-        .fail(function () {
+        .fail(function (err) {
+            checkExpiredSession(err);
             Materialize.toast("Failed to update schedule", 5000, "red darken-4")
         });
 }

--- a/src/Athena/Content/js/studentSetup.js
+++ b/src/Athena/Content/js/studentSetup.js
@@ -13,6 +13,7 @@ function updateEnrolledInstitutions(studentId, focus) {
             setInstitutionResults(studentId, enrolledInstitutions);
         })
         .fail(function (err) {
+            checkExpiredSession(err);
             setInstitutionResults(studentId, []);
             console.error("Failed to get institutions");
         });
@@ -30,6 +31,7 @@ function updateEnrolledPrograms(studentId, focus) {
             setProgramResults(studentId,  enrolledPrograms);
         })
         .fail(function(err) {
+            checkExpiredSession(err);
             setProgramResults(studentId,  []);
             console.error("Failed to get Programs");
         });
@@ -99,7 +101,8 @@ function setInstutitonSearchResults(studentId, data) {
                     type: 'PUT',
                     complete: function () {
                         updateEnrolledInstitutions(studentId, true);
-                    }
+                    },
+                    error: checkExpiredSession
                 });
                 card.remove();
             });
@@ -130,7 +133,8 @@ function setInstitutionResults(studentId, data) {
                     type: 'DELETE',
                     complete: function () {
                         updateEnrolledInstitutions(studentId, true);
-                    }
+                    },
+                    error: checkExpiredSession
                 });
             });
 
@@ -160,7 +164,8 @@ function setProgramResults(studentId, data) {
                     type: 'DELETE',
                     complete: function() {
                         updateEnrolledPrograms(studentId, true);
-                    }
+                    },
+                    error: checkExpiredSession
                 });
             });
 
@@ -190,7 +195,8 @@ function setProgramSearchResults(studentId, data) {
                     type: 'PUT',
                     complete: function () {
                         updateEnrolledPrograms(studentId, true);
-                    }
+                    },
+                    error: checkExpiredSession
                 });
                 card.remove();
             });
@@ -227,7 +233,8 @@ export function init (studentId) {
                         data: { q: q }
                     }).done(function(data){
                         setInstutitonSearchResults(studentId, data)
-                    }).fail(function() {
+                    }).fail(function(err) {
+                        checkExpiredSession(err);
                         setInstutitonSearchResults(studentId,  []);
                         console.error("Failed to search institutions");
                     });
@@ -260,7 +267,8 @@ export function init (studentId) {
                         }
                     }).done(function(data) {
                         setProgramSearchResults(studentId, data)
-                    }).fail(function(data) {
+                    }).fail(function(err) {
+                        checkExpiredSession(err);
                         setProgramSearchResults(studentId, []);
                         console.error("Failed to search programs");
                     });

--- a/src/Athena/Views/Shared/_Layout.cshtml
+++ b/src/Athena/Views/Shared/_Layout.cshtml
@@ -41,6 +41,13 @@
 <script type="text/javascript" src="@Url.Content("~/athena.js")"></script>
 <script type="text/javascript">
     const apiRoot = "@Url.Content("~/api/v1")";
+    
+    function checkExpiredSession(err) {
+        if (err.status === 401 || err.status === 403) {
+            window.location.replace("@Url.Action(nameof(AccountController.Login), "Account", new { returnUrl = Url.RouteUrl(ViewContext.RouteData.Values) })");
+        }
+    }
+    
     $(function () {
         $('.modal').modal();
         $('.print-trigger').click(function () {


### PR DESCRIPTION
Fixes #175.

Extremely heavy-handed, should probably be tweaked later, but `tl;dr` ASP.NET seems to do two different things when the session expires and when the security stamp expires.

* If the user still has a valid browser session, but the security stamp cookie has expired, you get a 403
* If the browser's cookie has expired, you get a 401

This means that there's no way to differentiate between a user not being able to access a resource (403) and a user not being logged in (401) in this check. For the expo, I'm fine with this. Thoughts?